### PR TITLE
[Delete] software.jpeg:Zone.Identifier

### DIFF
--- a/src/assets/img/software.jpeg:Zone.Identifier
+++ b/src/assets/img/software.jpeg:Zone.Identifier
@@ -1,4 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=https://www.google.com/
-HostUrl=https://lh3.googleusercontent.com/proxy/auWB-05OCID8B-6vvRXdc40nyHzeu7FT3DrZ282rwSe8dRfXVvn5VTSk1Ury6fzcytGe08PgQ7veOvST_7j7kd_AsJEWHbwcUd5NidxSz0j9CT0posptQIQUCG2V6ExLMg


### PR DESCRIPTION
Deleted `software.jpeg:Zone.Identifier` from `src/assets/img` as it was causing cloning issues. Windows cannot have a file that has ':' in their name